### PR TITLE
Improve stability with native global text scaling and refined hook handling

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,0 +1,22 @@
+#+TITLE: Changelog
+#+AUTHOR: emacs-presentation-mode maintainers
+
+All notable changes to this project will be documented in this file.
+The format is based on [[https://keepachangelog.com/en/1.1.0/][Keep a Changelog]], and this project aims to adhere to [[https://semver.org/spec/v2.0.0.html][Semantic Versioning]].
+
+* Unreleased
+** Added
+- Add ~presentation-mode-text-scale-remap-header-line~ custom variable to let header lines follow presentation scaling.
+- Add ~presentation-mode-map~ as the dedicated keymap for the minor mode.
+- Add ~presentation-use-global-text-scale-adjust~ custom variable to select scaling engine:
+  - ~auto~: use ~global-text-scale-adjust~ when available; if a buffer matches ~presentation-mode-ignore-minor-modes~, fall back to the previous implementation.
+  - ~always~: always use ~global-text-scale-adjust~; ~presentation-mode-ignore-minor-modes~ is not honored.
+  - ~never~: always use the previous buffer-local implementation (child frames/posframe popups may display less smoothly).
+** Changed
+- Text scaling now uses Emacs 29+ ~global-text-scale-adjust~ for improved stability.
+  - The previous buffer-local approach could flicker and mis-handle child frames (aka posframe popups); the new default avoids those issues.
+- ~presentation-off-hook~ now runs on the next command cycle (via ~post-command-hook~) after the mode is disabled to prevent accidental re-entry/recursive loops from teardown side effects (e.g., theme or scaling changes).
+- Mode teardown resets text scaling with ~presentation--reset-all-scales~, preferring ~global-text-scale-adjust~ when allowed and falling back to per-buffer resets only when necessary.
+** Fixed
+- Prevented excessive recursion when ignored buffers or theme changes re-enter scaling logic.
+- Ensured ~presentation-mode-ignore-minor-modes~ is respected (any matching minor mode now skips scaling).

--- a/README.org
+++ b/README.org
@@ -1,6 +1,11 @@
 * Emacs Presentation Mode
-*Presentation mode* is a global minor mode to zoom characters.  This mode applies the effect of ~text-scale-mode~ to all buffers.
-This feature help you to present Emacs edit / operation to the audience in front of the screen.
+
+Present your Emacs sessions with readable text across every buffer, while keeping a quick toggle and hooks for tailoring the UI during demos.
+
+** What this package provides
+- A global minor mode (~presentation-mode~) that applies ~text-scale-mode~ across all buffers/windows for easier screen-sharing or live demos.
+- Explicit on/off toggle with lighter, plus hooks (~presentation-on-hook~, ~presentation-off-hook~) to adjust your UI during presentations (e.g., hide line numbers, switch completion UI).
+- Optional delegation to Emacs 29’s ~global-text-scale-adjust~ for synchronized scaling while keeping the above toggle and hooks.
 
 [[./emacs-presentation.jpg]]
 
@@ -19,27 +24,40 @@ It is well known that how to change the font size of Emacs in GUI is difficult.
 However, this mode is *NOT* intended for permanent font size change.
 - https://www.gnu.org/software/emacs/manual/html_node/elisp/Parameter-Access.html
 - https://www.gnu.org/software/emacs/manual/html_node/emacs/Frame-Parameters.html
+*** About ~global-text-scale-adjust~ (Emacs 29+, non-persistent)
+- Emacs 29 ships ~global-text-scale-adjust~; it synchronizes scaling across windows but does not persist font size between sessions.
+- Try it first if you only need quick, global scaling. Continue here when you need explicit on/off control or hooks for presentation-specific tweaks.
 
 ** Customization
 You can switch modes for screen decoration by defining hook for on/off.
 #+BEGIN_SRC emacs-lisp
 (defun my-presentation-on ()
-  (helm-mode -1)
-  ;; (global-display-line-numbers-mode -1)
-  (ido-ubiquitous-mode 1)
-  (bind-key "M-x" #'smex))
+  (vertico-mode -1)
+  (global-display-line-numbers-mode -1)
+  (fido-mode 1)
+  (mapc #'disable-theme custom-enabled-themes)
+  (modus-themes-select 'modus-vivendi))
 
 (defun my-presentation-off ()
-  (ido-ubiquitous-mode -1)
-  ;; (global-display-line-numbers-mode 1)
-  (helm-mode 1)
-  (bind-key "M-x" #'helm-smex))
+  (fido-mode -1)
+  (global-display-line-numbers-mode 1)
+  (vertico-mode 1)
+  (mapc #'disable-theme custom-enabled-themes)
+  (modus-themes-select 'modus-operandi))
 
 (add-hook 'presentation-on-hook #'my-presentation-on)
 (add-hook 'presentation-off-hook #'my-presentation-off)
 #+END_SRC
 Typically it is on/off of ~display-line-numbers-mode~ (or ~linum-mode~) /(although I do not use it)/.
 I normally use [[https://emacs-helm.github.io/helm/][Helm]], but I think that [[https://www.gnu.org/software/emacs/manual/html_node/ido/index.html][IDO]] is more compact and easy to see during presentation.
+
+*** Global scaling (Emacs 29+)
+- Emacs 29 added ~global-text-scale-adjust~ in ~face-remap.el~. When available, ~presentation-mode~ delegates scaling to it so all frames/windows stay in sync.
+- Control delegation with ~presentation-use-global-text-scale-adjust~:
+  - ~auto~ (default): use global adjust when available and no ignored buffers need protection.
+  - ~always~: force global adjust when available (no fallback for ignored buffers).
+  - ~never~: always use the legacy buffer-local ~text-scale-mode~ behavior.
+- If any buffer should be excluded (e.g., matches ~presentation-mode-ignore-minor-modes~ or has ~presentation-disable~ set), delegation is disabled in ~auto~ mode and buffer-local scaling is used to keep those buffers unchanged.
 ** Difference from other methods
 *** vs [[https://www.emacswiki.org/emacs/GlobalTextScaleMode][GlobalTextScaleMode]] (Emacs Wiki)
 Although the content of this article is simple, it does not provide a way to recover buffers.
@@ -52,6 +70,12 @@ This package is probably not compatible with ~presentation.el~, but please use t
 *** vs [[https://github.com/takaxp/org-tree-slide][Org Tree Slide]] and [[https://github.com/rlister/org-present][org-present]]
 These packages are simple presentations using org-mode.
 By using these with org-babel, it may be possible to perform live coding of arbitrary languages.
+*** vs global-text-scale-adjust (Emacs 29+)
+- If you only want to synchronize text scale across all windows, a simple remap can suffice:
+  #+BEGIN_SRC emacs-lisp
+  (define-key map [remap text-scale-adjust] #'global-text-scale-adjust)
+  #+END_SRC
+- ~presentation-mode~ adds value when you need explicit on/off toggling via a minor mode and custom hooks (~presentation-on-hook~, ~presentation-off-hook~) to adjust UI (e.g., hide line numbers, switch completion UI) during presentations.
 
 ** Video
 [[./emacs-presentation.gif]]

--- a/README.org
+++ b/README.org
@@ -1,56 +1,52 @@
 * Emacs Presentation Mode
+Present your Emacs sessions with readable text across all buffers, featuring a quick toggle and hooks for tailoring your UI during live demos.
 
-Present your Emacs sessions with readable text across every buffer, while keeping a quick toggle and hooks for tailoring the UI during demos.
-
-** What this package provides
-- A global minor mode (~presentation-mode~) that applies ~text-scale-mode~ across all buffers/windows for easier screen-sharing or live demos.
-- Explicit on/off toggle with lighter, plus hooks (~presentation-on-hook~, ~presentation-off-hook~) to adjust your UI during presentations (e.g., hide line numbers, switch completion UI).
-- Optional delegation to Emacs 29’s ~global-text-scale-adjust~ for synchronized scaling while keeping the above toggle and hooks.
+** Key Features
+- *Global Scaling*: A global minor mode (~presentation-mode~) that scales text across all windows for crystal-clear screen sharing.
+- *UI Automation*: Use hooks (~presentation-on-hook~ / ~off-hook~) to automatically adjust your environment (e.g., hide line numbers, switch themes).
+- *Emacs 29+ Ready*: Optionally delegates to native ~global-text-scale-adjust~ while maintaining toggle and hook support.
+- *Persistence*: Automatically remembers and restores your last used scale.
 
 [[./emacs-presentation.jpg]]
 
 ** How to use
- 1. Execute ~M-x presentation-mode~ to start the presentation.
- 2. Adjust scale size by ~C-x C-+~ or ~C-x C--~
-    See https://www.gnu.org/software/emacs/manual/html_node/emacs/Text-Scale.html
- 3. After the presentation, execute ~M-x presentation-mode~ again.
- 4. And then execute ~M-x presentation-mode~ again, the last scale will be reproduced.
- 5. If you want to persistize its size as the default size of presentation-mode
-    after restarting Emacs, set ~presentation-default-text-scale~.
-
-** Notice
-*** Not for "persistent font size change"
-It is well known that how to change the font size of Emacs in GUI is difficult.
-However, this mode is *NOT* intended for permanent font size change.
-- https://www.gnu.org/software/emacs/manual/html_node/elisp/Parameter-Access.html
-- https://www.gnu.org/software/emacs/manual/html_node/emacs/Frame-Parameters.html
-*** About ~global-text-scale-adjust~ (Emacs 29+, non-persistent)
-- Emacs 29 ships ~global-text-scale-adjust~; it synchronizes scaling across windows but does not persist font size between sessions.
-- Try it first if you only need quick, global scaling. Continue here when you need explicit on/off control or hooks for presentation-specific tweaks.
-
+ 1. Execute ~M-x presentation-mode~ to start your session.
+ 2. Adjust the scale using ~C-x C-+~ or ~C-x C--~.
+    (Reference: [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Text-Scale.html][Emacs Manual: Text Scale]])
+ 3. Toggle ~M-x presentation-mode~ again to stop and restore your original UI.
+ 4. When re-enabled, the mode automatically reproduces your last used scale.
+ 5. To set a permanent starting scale, customize ~presentation-default-text-scale~.
+** Technical Notes
+*** Not for permanent font configuration
+This mode is *NOT* intended for permanent font size changes. For global font configuration, refer to:
+- [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Parameter-Access.html][Access to Frame Parameters (Elisp Manual)]]
+- [[https://www.gnu.org/software/emacs/manual/html_node/emacs/Frame-Parameters.html][Frame Parameters (Emacs Manual)]]
+*** Emacs 29+ Global Scaling
+Emacs 29 introduced ~global-text-scale-adjust~. This package can delegate to it while providing the extra benefit of hooks and persistence.
+- Control delegation via ~presentation-use-global-text-scale-adjust~:
+  - ~auto~ (default): uses global adjust when available and no buffers are ignored.
+  - ~always~: forces global adjust.
+  - ~never~: always uses the legacy buffer-local ~text-scale-mode~.
 ** Customization
-You can switch modes for screen decoration by defining hook for on/off.
+Use hooks to define a "Presentation Theme" that triggers automatically.
 #+BEGIN_SRC emacs-lisp
 (defun my-presentation-on ()
-  (vertico-mode -1)
-  (global-display-line-numbers-mode -1)
-  (fido-mode 1)
-  (mapc #'disable-theme custom-enabled-themes)
+  "Setup UI for presentations."
+  (vertico-flat-mode -1)
+  ;; (global-display-line-numbers-mode -1)
   (modus-themes-select 'modus-vivendi))
 
 (defun my-presentation-off ()
-  (fido-mode -1)
-  (global-display-line-numbers-mode 1)
-  (vertico-mode 1)
-  (mapc #'disable-theme custom-enabled-themes)
+  "Restore UI after presentations."
+  (vertico-flat-mode 1)
+  ;; (global-display-line-numbers-mode 1)
   (modus-themes-select 'modus-operandi))
 
 (add-hook 'presentation-on-hook #'my-presentation-on)
 (add-hook 'presentation-off-hook #'my-presentation-off)
 #+END_SRC
 Typically it is on/off of ~display-line-numbers-mode~ (or ~linum-mode~) /(although I do not use it)/.
-I normally use [[https://emacs-helm.github.io/helm/][Helm]], but I think that [[https://www.gnu.org/software/emacs/manual/html_node/ido/index.html][IDO]] is more compact and easy to see during presentation.
-
+I normally use [[https://github.com/emacs-straight/vertico][Vertico]]; with ~vertico-flat-mode~ candidates stay on one horizontal line, minimizing vertical space during live demos. [[https://www.gnu.org/software/emacs/manual/html_node/ido/index.html][IDO]] / ~fido-mode~ is another compact built-in UI option.
 *** Global scaling (Emacs 29+)
 - Emacs 29 added ~global-text-scale-adjust~ in ~face-remap.el~. When available, ~presentation-mode~ delegates scaling to it so all frames/windows stay in sync.
 - Control delegation with ~presentation-use-global-text-scale-adjust~:
@@ -73,9 +69,17 @@ By using these with org-babel, it may be possible to perform live coding of arbi
 *** vs global-text-scale-adjust (Emacs 29+)
 - If you only want to synchronize text scale across all windows, a simple remap can suffice:
   #+BEGIN_SRC emacs-lisp
-  (define-key map [remap text-scale-adjust] #'global-text-scale-adjust)
+  (define-key global-map [remap text-scale-adjust] #'global-text-scale-adjust)
   #+END_SRC
 - ~presentation-mode~ adds value when you need explicit on/off toggling via a minor mode and custom hooks (~presentation-on-hook~, ~presentation-off-hook~) to adjust UI (e.g., hide line numbers, switch completion UI) during presentations.
-
+*** Comparison with Alternatives
+| Feature           | presentation.el | global-text-scale | default-text-scale |
+|-------------------+-----------------+-------------------+--------------------|
+| Global Scaling    | Yes             | Yes               | Yes                |
+| UI Hooks (On/Off) | *Yes*           | No                | No                 |
+| Scale Persistence | Yes             | No                | Yes                |
+| Buffer Exclusion  | Yes             | No                | No                 |
+- *vs Org-specific tools* (~org-tree-slide~, ~org-present~): These are for slide decks. ~presentation.el~ is for general live-coding and demoing any buffer.
+- *vs default-text-scale*: Use ~default-text-scale~ for permanent global scaling. Use ~presentation.el~ for temporary presentation mode with environment tweaks.
 ** Video
 [[./emacs-presentation.gif]]

--- a/presentation.el
+++ b/presentation.el
@@ -115,42 +115,173 @@ your init.el."
   "If non-nil, text scaling may change font size of header lines too."
   :type 'boolean)
 
+(defcustom presentation-use-global-text-scale-adjust 'auto
+  "Control use of `global-text-scale-adjust' when available.
+
+- auto: use it when present and no ignored buffers require local scaling.
+- always: use it whenever present; do not fall back for ignored buffers.
+- never: never use it; rely on buffer-local `text-scale-mode' operations."
+  :type '(choice (const :tag "Auto-detect" auto)
+                 (const :tag "Always use global" always)
+                 (const :tag "Never use global" never)))
+
 ;; Buffer local variables:
 (defvar-local presentation-disable nil)
 
 ;; Variables:
 (defvar presentation-last-text-scale nil)
+(defvar presentation--current-global-level 0
+  "Track current global text scale when using `global-text-scale-adjust'.")
+(defvar presentation--fallback-used nil
+  "Non-nil when buffer-local scaling fallback was used in this session.")
+(defvar presentation--pending-off-hook nil)
 
 ;; Functions:
 
+(defun presentation--reset-global-scale ()
+  "Reset global text scale to default when previously adjusted."
+  (when (and (eval-when-compile (fboundp 'global-text-scale-adjust))
+             (/= presentation--current-global-level 0))
+    (let ((last-command-event ?0))
+      (global-text-scale-adjust 0))
+    (setq presentation--current-global-level 0)))
+
+(defun presentation--reset-all-scales ()
+  "Reset text scaling using global adjust when suitable, else per-buffer."
+  (let ((use-global
+         (and (fboundp 'global-text-scale-adjust)
+              (pcase presentation-use-global-text-scale-adjust
+                ('always t)
+                ('auto (not (presentation--buffers-require-local-scaling-p)))
+                (_ nil)))))
+    (when use-global
+      (let ((last-command-event ?0))
+        (global-text-scale-adjust 0))
+      (setq presentation--current-global-level 0))
+    (when (and (not use-global) presentation--fallback-used)
+      (presentation--reset-global-scale)
+      (save-selected-window
+        (cl-loop for buf in (buffer-list)
+                 do (with-current-buffer buf
+                      (unless (presentation-ignore-current-buffer)
+                        (text-scale-set 0))))))
+    (setq presentation--fallback-used nil)))
+
+(defun presentation--buffers-require-local-scaling-p ()
+  "Return non-nil if any buffer should be excluded from global scaling.
+
+We avoid `global-text-scale-adjust' when a buffer would be ignored, because
+global face changes cannot be scoped per buffer."
+  (cl-loop for buf in (buffer-list)
+           thereis (with-current-buffer buf
+                     (presentation-ignore-current-buffer))))
+
+(defun presentation--run-delayed-off-hook ()
+  "Helper to run `presentation-off-hook' once, ignoring errors."
+  (when presentation--pending-off-hook
+    (setq presentation--pending-off-hook nil)
+    (ignore-errors
+      (run-hooks 'presentation-off-hook)))
+  (remove-hook 'post-command-hook #'presentation--run-delayed-off-hook))
+
+(defun presentation--use-global-adjust-p ()
+  "Return non-nil when `global-text-scale-adjust' can be used."
+  (when (eval-when-compile (fboundp 'global-text-scale-adjust))
+    (pcase presentation-use-global-text-scale-adjust
+      ('always t)
+      ('auto (not (presentation--buffers-require-local-scaling-p)))
+      (_ nil))))
+
+(defun presentation--global-text-scale-set (level)
+  "Set global text scale LEVEL using `global-text-scale-adjust'."
+  (let ((delta (- level presentation--current-global-level)))
+    (cond
+     ((= level 0)
+      (let ((last-command-event ?0))
+        (global-text-scale-adjust 0)))
+     ((> delta 0)
+      (let ((last-command-event ?+))
+        (global-text-scale-adjust delta)))
+     ((< delta 0)
+      (let ((last-command-event ?-))
+        (global-text-scale-adjust (- delta)))))
+    (setq presentation--current-global-level level)))
+
 (defun presentation--text-scale-set (&rest _args)
-  "Set `text-scale-mode-amount' for each buffer."
+  "Set `text-scale-mode-amount' for each buffer or via global adjust."
   (setq presentation-last-text-scale text-scale-mode-amount)
-  (presentation-windows-text-scale-set text-scale-mode-amount))
+  (if (presentation--use-global-adjust-p)
+      (presentation--global-text-scale-set text-scale-mode-amount)
+    (presentation-windows-text-scale-set text-scale-mode-amount)))
+
+(defun presentation--text-scale-set-around (orig-fn level)
+  "Around advice for ORIG-FN when delegating `text-scale-set' LEVEL.
+Delegates to `global-text-scale-adjust' when enabled, else calls ORIG-FN."
+  (if (presentation--use-global-adjust-p)
+      (progn
+        (setq presentation-last-text-scale level)
+        (presentation--global-text-scale-set level))
+    (presentation--reset-global-scale)
+    (funcall orig-fn level)
+    (presentation--text-scale-set)))
+
+(defun presentation--text-scale-increase-around (orig-fn inc)
+  "Around advice for ORIG-FN when delegating `text-scale-increase' INC.
+Delegates to `global-text-scale-adjust' when enabled, else calls ORIG-FN."
+  (if (presentation--use-global-adjust-p)
+      (let* ((base (or presentation-last-text-scale text-scale-mode-amount 0))
+             (level (+ base inc)))
+        (setq presentation-last-text-scale level)
+        (presentation--global-text-scale-set level))
+    (presentation--reset-global-scale)
+    (funcall orig-fn inc)
+    (presentation--text-scale-set)))
 
 (defun presentation--text-scale-apply ()
   "Set `presentation-last-text-scale' for each buffer."
-  (presentation-windows-text-scale-set presentation-last-text-scale))
+  (if (presentation--use-global-adjust-p)
+      (presentation--global-text-scale-set presentation-last-text-scale)
+    (presentation-windows-text-scale-set presentation-last-text-scale)))
 
 (defun presentation-ignore-current-buffer ()
-  "Return non-NIL if current-burrer should be ignore for presentation."
+  "Return non-NIL if `current-buffer' should be ignore for presentation."
   (or presentation-disable
       (memq major-mode presentation-mode-ignore-major-modes)
-      (cl-loop for m in presentation-mode-ignore-minor-modes
-               always (and (boundp m) (symbol-value m)))))
+      (cl-some (lambda (m) (and (boundp m) (symbol-value m)))
+               presentation-mode-ignore-minor-modes)))
 
 (defun presentation-windows-text-scale-set (level)
   "Set LEVEL for each buffer."
-  (save-selected-window
-    (walk-windows
-     (lambda (win)
-       (with-selected-window win
-         (when (eval-when-compile (boundp 'text-scale-remap-header-line))
-           (setq text-scale-remap-header-line presentation-mode-text-scale-remap-header-line))
-         (unless (presentation-ignore-current-buffer)
-           (setq text-scale-mode-amount level)
-           (text-scale-mode (if (zerop text-scale-mode-amount) -1 1)))))
-     t t)))
+  (if (presentation--use-global-adjust-p)
+      (presentation--global-text-scale-set level)
+    (setq presentation--fallback-used t)
+    (presentation--reset-global-scale)
+    (save-selected-window
+      (walk-windows
+       (lambda (win)
+         (with-selected-window win
+           (when (eval-when-compile (boundp 'text-scale-remap-header-line))
+             (setq text-scale-remap-header-line presentation-mode-text-scale-remap-header-line))
+           (unless (presentation-ignore-current-buffer)
+             (setq text-scale-mode-amount level)
+             (text-scale-mode (if (zerop text-scale-mode-amount) -1 1)))))
+       t t))))
+
+(defun presentation--add-scale-advice ()
+  "Install text scale advices."
+  (if (presentation--use-global-adjust-p)
+      (progn
+        (advice-add 'text-scale-set :around #'presentation--text-scale-set-around)
+        (advice-add 'text-scale-increase :around #'presentation--text-scale-increase-around))
+    (advice-add 'text-scale-set :after #'presentation--text-scale-set)
+    (advice-add 'text-scale-increase :after #'presentation--text-scale-set)))
+
+(defun presentation--remove-scale-advice ()
+  "Remove text scale advices."
+  (advice-remove 'text-scale-set #'presentation--text-scale-set-around)
+  (advice-remove 'text-scale-increase #'presentation--text-scale-increase-around)
+  (advice-remove 'text-scale-set #'presentation--text-scale-set)
+  (advice-remove 'text-scale-increase #'presentation--text-scale-set))
 
 ;; Mode:
 (defvar-keymap presentation-mode-map
@@ -166,22 +297,18 @@ your init.el."
   :require 'presentation
   (if presentation-mode
       (save-selected-window
-        (advice-add 'text-scale-set :after #'presentation--text-scale-set)
-        (advice-add 'text-scale-increase :after #'presentation--text-scale-set)
+        (setq presentation--fallback-used nil)
+        (presentation--add-scale-advice)
         (add-hook 'window-configuration-change-hook  #'presentation--text-scale-apply)
         (let ((text-scale-mode-amount (or (when presentation-keep-last-text-scale presentation-last-text-scale)
                                           presentation-default-text-scale)))
           (presentation--text-scale-set))
         (run-hooks 'presentation-on-hook))
-    (advice-remove 'text-scale-set #'presentation--text-scale-set)
-    (advice-remove 'text-scale-increase #'presentation--text-scale-set)
+    (presentation--remove-scale-advice)
     (remove-hook 'window-configuration-change-hook  #'presentation--text-scale-apply)
-    (save-selected-window
-      (cl-loop for buf in (buffer-list)
-               do (with-current-buffer buf
-                    (unless (presentation-ignore-current-buffer)
-                      (text-scale-set 0))))
-      (run-hooks 'presentation-off-hook))))
+    (presentation--reset-all-scales)
+    (setq presentation--pending-off-hook t)
+    (add-hook 'post-command-hook #'presentation--run-delayed-off-hook)))
 
 (provide 'presentation)
 ;;; presentation.el ends here

--- a/presentation.el
+++ b/presentation.el
@@ -1,6 +1,6 @@
-;;; presentation.el --- Display large character for presentation  -*- lexical-binding: t; -*-
+;;; presentation.el --- Scale text globally and adjust UI for presentations  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025  USAMI Kenta
+;; Copyright (C) 2026  USAMI Kenta
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Keywords: environment, faces, frames
@@ -25,46 +25,39 @@
 
 ;;; Commentary:
 
-;; Presentation mode is a global minor mode to zoom characters.
-;; This mode applies the effect of `text-scale-mode' to all buffers.
-;; This feature help you to present Emacs edit / operation to the audience
-;; in front of the screen.
+;; Presentation mode is a global minor mode that provides a distraction-free
+;; environment for live demos.  It scales text across all buffers and provides
+;; hooks to automate UI changes, such as toggling line numbers or switching themes.
+;;
+;; Key features:
+;; - Global text scaling for high visibility on projectors/screen-sharing.
+;; - `presentation-on-hook' and `presentation-off-hook' for UI automation.
+;; - Persistence of scale size between sessions.
+;; - Optional integration with Emacs 29's `global-text-scale-adjust'.
 ;;
 ;; ## How to use
 ;;
 ;;  1. Execute `M-x presentation-mode' to start the presentation.
-;;  2. Adjust scale size by `C-x C-+' or `C-x C--'
-;;     See https://www.gnu.org/software/emacs/manual/html_node/emacs/Text-Scale.html
-;;  3. After the presentation, execute `M-x presentation-mode` again.
-;;  4. And then execute `M-x presentation-mode` again, the last scale will be reproduced.
-;;  5. If you want to persistize its size as the default size of presentation-mode
-;;     after restarting Emacs, set `presentation-default-text-scale`.
+;;  2. Adjust scale size using `C-x C-+' or `C-x C--'.
+;;     (See: https://www.gnu.org/software/emacs/manual/html_node/emacs/Text-Scale.html )
+;;  3. Execute `M-x presentation-mode' again to end and restore your UI.
+;;  4. Toggling the mode back on will automatically reproduce the last used scale.
+;;  5. To set a permanent default scale, customize `presentation-default-text-scale'.
 ;;
-;; ## Notice
+;; ## Technical Notes
 ;;
-;; ### Not for "persistent font size change"
+;; ### Permanent font changes
 ;;
-;; It is well known that how to change the font size of Emacs in GUI is difficult.
-;; However, this mode is *NOT* intended for permanent font size change.
-;;
+;; This mode is NOT intended for permanent font configuration.  If you wish to
+;; change the default font size of Emacs frames permanently, please refer to:
 ;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Parameter-Access.html
-;; https://www.gnu.org/software/emacs/manual/html_node/emacs/Frame-Parameters.html
 ;;
-;; ## Difference from other methods
+;; ## Comparison
 ;;
-;; ### vs GlobalTextScaleMode (Emacs Wiki)
-;;
-;; Although the content of this article is simple, it does not provide a way to
-;; recover buffers.
-;; https://www.emacswiki.org/emacs/GlobalTextScaleMode
-;;
-;; ### Org Tree Slide / org-present
-;;
-;; These packages are simple presentations using org-mode.
-;; By using these with org-babel, it may be possible to perform live coding of
-;; arbitrary languages.
-;; https://github.com/takaxp/org-tree-slide
-;; https://github.com/rlister/org-present
+;; - vs `default-text-scale': Use `default-text-scale' for permanent global
+;;   scaling.  Use `presentation.el' for temporary demo environments.
+;; - vs `org-tree-slide' / `org-present': These are specific to Org-mode slides.
+;;   `presentation.el' is for general Emacs usage and live-coding.
 ;;
 
 ;;; Code:


### PR DESCRIPTION
This update focuses on improving the stability and UI consistency of presentation sessions by leveraging Emacs 29+ native capabilities and refining the internal hook lifecycle.

## Key Improvement: Child Frame (posframe) Stability
The previous implementation, which relied on buffer-local text scaling, often caused "jitter" or inconsistent font sizes in child frames (commonly known as posframe popups). By shifting the default scaling mechanism to the native global engine, the UI now remains smooth and visually consistent across all windows and popups during live demos.

## New Customization: `presentation-use-global-text-scale-adjust`
You can now control the scaling engine via the `presentation-use-global-text-scale-adjust` variable:

- **`auto` (Default)**: Uses `global-text-scale-adjust` when available. However, if any buffer is explicitly ignored (e.g., via `presentation-mode-ignore-minor-modes`), it automatically falls back to the legacy buffer-local implementation to ensure those buffers remain unchanged.
- **`always`**: Forces the use of the native global engine. This provides the most stable visual experience, though ignore-rules are bypassed.
- **`never`**: Forces the legacy buffer-local behavior. Useful for Emacs < 29 or when you need strict per-buffer scaling control despite the potential for minor UI jitters in popups.

## How to Rollback
If the new scaling engine does not work as expected in your environment, you can easily revert to the legacy buffer-local scaling logic by adding the following to your configuration:

```elisp
(setq presentation-use-global-text-scale-adjust 'never)
```

> [!TIP]
> If you find this setting necessary, I would greatly appreciate it if you could leave a comment on this PR with details about your environment and use case. Your feedback will be a huge help for further refinements!

## Refined Hook Lifecycle
The `presentation-off-hook` now runs during the next command cycle (via `post-command-hook`) after the mode is disabled. This delay prevents accidental re-entry or recursive loops that could occur when complex teardown actions (like theme switching or scale resetting) trigger buffer-level updates.

## Pro-tip: Simple Global Scaling Alternative
`presentation-mode` provides significant value through its on/off hooks (for hiding line numbers, switching themes, etc.) and persistence. However, if you only need basic synchronized text scaling across all buffers without the extra features, you can achieve this in Emacs 29+ using a simple remap:

```elisp
(define-key global-map [remap text-scale-adjust] #'global-text-scale-adjust)
```

> [!NOTE]
> I plan to continue maintaining `presentation.el` to meet my own presentation and live-coding needs. Please feel free to share any feedback or suggestions you may have, as I intend to keep refining this package.